### PR TITLE
Bump gmt from 6.0.0a16 to 6.0.0a17 and update other dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,15 +3,15 @@ channels:
     - conda-forge
     - conda-forge/label/dev
 dependencies:
-    - python=3.6
-    - pip=9.0.*
-    - gmt=6.0.0a16
-    - numpy=1.14.*
-    - pandas=0.23.*
-    - xarray=0.10.*
-    - packaging=17.1
+    - gmt=6.0.0a17
+    - ipython=7.1.*
     - jupyter=1.0.0
-    - notebook=5.5.0
-    - ipython=6.4.*
+    - notebook=5.7.0
+    - numpy=1.15.*
+    - packaging=18.0
+    - pandas=0.23.*
+    - pip=18.*
+    - python=3.6
+    - xarray=0.10.*
     - pip:
-        - https://github.com/GenericMappingTools/gmt-python/archive/0005152780528c7248369fb1446a9670383f2b19.zip
+        - https://github.com/GenericMappingTools/gmt-python/archive/0.1a3-123-g2127ad0.zip


### PR DESCRIPTION
**Description of proposed changes**

Updating the binder demo's dependencies to newer versions. Also update gmt-python version to https://github.com/GenericMappingTools/gmt-python/commit/2127ad0447ed28c2aff8e78cb628d54592209801.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes https://github.com/GenericMappingTools/gmt-python/issues/234

Test using https://mybinder.org/v2/gh/weiji14/try-gmt-python/432a66fbd9138220422aba24fee14d84b5a48325?filepath=try-gmt-python.ipynb